### PR TITLE
Fix tc_down with exclusivity flag issues

### DIFF
--- a/tc_down_template.sh
+++ b/tc_down_template.sh
@@ -17,5 +17,6 @@ while read i;
 do
     echo "- $i"
     tc qdisc del dev $i ingress
+    tc qdisc del dev $i root
     tc filter del dev $i root
 done < network_taps


### PR DESCRIPTION
When running tc_up.sh with a different set of interfaces prior to pulling them down, there may arise a situation where the subsequent tc_up run causes an error relating to exclusivity. The fix is to have the tc_down script remove "root" alongside "ingress" on the qdisc